### PR TITLE
fix: Snackbar is misaligned during startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -198,6 +198,7 @@ open class DeckPicker :
     private var studyoptionsFrame: View? = null // not lateInit - can be null
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var recyclerView: RecyclerView
+    lateinit var mainView: View
     private lateinit var recyclerViewLayoutManager: LinearLayoutManager
     private lateinit var deckListAdapter: DeckAdapter
     lateinit var exportingDelegate: ActivityExportingDelegate
@@ -426,8 +427,8 @@ open class DeckPicker :
         }
 
         setContentView(R.layout.homescreen)
+        mainView = findViewById<View>(android.R.id.content)
         handleStartup()
-        val mainView = findViewById<View>(android.R.id.content)
 
         // check, if tablet layout
         studyoptionsFrame = findViewById(R.id.studyoptions_fragment)
@@ -1477,7 +1478,10 @@ open class DeckPicker :
                 // Don't show new features dialog for development builds
                 InitialActivity.setUpgradedToLatestVersion(preferences)
                 val ver = resources.getString(R.string.updated_version, VersionUtils.pkgVersionName)
-                showSnackbar(ver, Snackbar.LENGTH_SHORT)
+                mainView.post {
+                    showSnackbar(ver, Snackbar.LENGTH_SHORT)
+                }
+
                 showStartupScreensAndDialogs(preferences, 2)
             }
         } else {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

Try to fix #16061

## Fixes
* Fixes #16061

## Approach
_How does this change address the problem?_

Put `showSnackbar` into the queue rather than calling it directly to avoid showing a misaligned snakbar.

The root cause of #16061 is probably that calling showSnackbar from `onCreate` is a BAD practice. But I'm not 100% sure about this.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
